### PR TITLE
Show links to access generated code easily in PR

### DIFF
--- a/.github/actions/post-comment-action/action.yml
+++ b/.github/actions/post-comment-action/action.yml
@@ -13,9 +13,6 @@ outputs: {}
 runs:
   using: 'composite'
   steps:
-    - name: check current directory
-      run: pwd
-      shell: bash
     - name: Install dependencies
       run: npm ci
       shell: bash

--- a/.github/actions/post-comment-action/action.yml
+++ b/.github/actions/post-comment-action/action.yml
@@ -12,10 +12,13 @@ outputs: {}
 runs:
   using: 'composite'
   steps:
+    - name: Show current path
+      run: pwd
+      shell: bash
     - name: Install dependencies
       run: npm ci
       shell: bash
-      working-directory: ./.github/actions/post-comment-action
+      # working-directory: ./.github/actions/post-comment-action
 
     - name: Post PR comment
       run: .github/actions/post-comment-action/main.js

--- a/.github/actions/post-comment-action/action.yml
+++ b/.github/actions/post-comment-action/action.yml
@@ -4,7 +4,23 @@ inputs:
   language:
     description: 'The language of the SDK'
     required: true
+  github-token:
+    description: 'The GitHub token'
+    required: true
+
 outputs: {}
 runs:
-  using: 'node16'
-  main: 'main.js'
+  using: 'composite'
+  steps:
+    - name: Install dependencies
+      run: npm ci
+      shell: bash
+      working-directory: ./.github/actions/post-comment-action
+
+    - name: Post PR comment
+      run: .github/actions/post-comment-action/main.js
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        NODE_PATH: ${{ github.workspace }}/.github/actions/post-comment-action/node_modules
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/post-comment-action/action.yml
+++ b/.github/actions/post-comment-action/action.yml
@@ -1,5 +1,5 @@
-name: 'Post and Manage PR Comment'
-description: 'Posts a comment to PR and deletes previous ones for the same job'
+name: 'Post and Manage PR Comments'
+description: 'Posts comments to PR and deletes previous ones for the same job'
 inputs:
   language:
     description: 'The language of the SDK'
@@ -9,12 +9,10 @@ inputs:
     required: true
 
 outputs: {}
+
 runs:
   using: 'composite'
   steps:
-    - name: Show current path
-      run: pwd
-      shell: bash
     - name: Install dependencies
       run: npm ci
       shell: bash

--- a/.github/actions/post-comment-action/action.yml
+++ b/.github/actions/post-comment-action/action.yml
@@ -13,6 +13,9 @@ outputs: {}
 runs:
   using: 'composite'
   steps:
+    - name: check current directory
+      run: pwd
+      shell: bash
     - name: Install dependencies
       run: npm ci
       shell: bash

--- a/.github/actions/post-comment-action/action.yml
+++ b/.github/actions/post-comment-action/action.yml
@@ -1,0 +1,10 @@
+name: 'Post and Manage PR Comment'
+description: 'Posts a comment to PR and deletes previous ones for the same job'
+inputs:
+  language:
+    description: 'The language of the SDK'
+    required: true
+outputs: {}
+runs:
+  using: 'node16'
+  main: 'main.js'

--- a/.github/actions/post-comment-action/action.yml
+++ b/.github/actions/post-comment-action/action.yml
@@ -18,12 +18,11 @@ runs:
     - name: Install dependencies
       run: npm ci
       shell: bash
-      # working-directory: ./.github/actions/post-comment-action
+      working-directory: ${{ github.action_path }}
 
     - name: Post PR comment
-      run: .github/actions/post-comment-action/main.js
+      run: node ${{ github.action_path }}/main.js
       shell: bash
-      working-directory: ${{ github.workspace }}
       env:
-        NODE_PATH: ${{ github.workspace }}/.github/actions/post-comment-action/node_modules
+        LANGUAGE: ${{ inputs.language }}
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -15,17 +15,13 @@ async function run() {
         const runId = context.runId;
         const jobName = context.job;
 
-        console.log(`context: ${JSON.stringify(context.repo, null, 2)}`);
-
-        // ジョブIDとステップ番号を取得
+        // Get the job ID and step number
         const { data: { jobs } } = await octokit.rest.actions.listJobsForWorkflowRun({
             owner: context.repo.owner,
             repo: context.repo.repo,
             run_id: runId,
         });
 
-
-        console.log(`jobs: ${JSON.stringify(jobs, null, 2)}`);
 
         const currentJob = jobs.find(job => job.name === jobName);
         if (!currentJob) {
@@ -48,7 +44,7 @@ async function run() {
         Generated code can be seen here(${language})\n\n[View logs here](${url})
         `;
 
-        // 以前のコメントを削除
+        // Delete the previous comment if it exists
         const { data: comments } = await octokit.rest.issues.listComments({
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -69,7 +65,7 @@ async function run() {
             }
         }
 
-        // 新しいコメントを投稿
+        // Post the new comment
         await octokit.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -24,6 +24,8 @@ async function run() {
             run_id: runId,
         });
 
+        console.log(`jobs: ${JSON.stringify(jobs, null, 2)}`);
+
         const currentJob = jobs.find(job => job.name === jobName);
         if (!currentJob) {
             throw new Error(`Job ${jobName} not found`);
@@ -48,6 +50,7 @@ async function run() {
             repo: context.repo.repo,
             issue_number: prNumber,
         });
+        console.log(`comments: ${JSON.stringify(comments, null, 2)}`);
 
         for (const comment of comments) {
             if (

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -15,6 +15,8 @@ async function run() {
         const runId = context.runId;
         const jobName = context.job;
 
+        console.log(`context: ${JSON.stringify(context.repo, null, 2)}`);
+
         // ジョブIDとステップ番号を取得
         const { data: { jobs } } = await octokit.rest.actions.listJobsForWorkflowRun({
             owner: context.repo.owner,
@@ -68,7 +70,7 @@ async function run() {
             body: `<!-- ${jobName}-comment -->\n${fullCommentBody}`,
         });
     } catch (error) {
-        core.setFailed(error.message);
+        core.setFailed(`Error in this script: ${error.message}`);
     }
 }
 

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -4,10 +4,11 @@ const core = require('@actions/core');
 async function run() {
     try {
         const token = process.env.GITHUB_TOKEN;
+        const language = process.env.LANGUAGE;
+
         const octokit = github.getOctokit(token);
         const context = github.context;
 
-        const commentBody = core.getInput('language');
         const stepName = 'Show diff'
 
         const prNumber = context.payload.pull_request.number;
@@ -37,7 +38,7 @@ async function run() {
 
         const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/jobs/${jobId}?pr=${prNumber}#step:${stepNumber}:1`;
 
-        const fullCommentBody = `Generated code can be seen here(${commentBody})\n\n[View logs here](${url})`;
+        const fullCommentBody = `Generated code can be seen here(${language})\n\n[View logs here](${url})`;
 
         // 以前のコメントを削除
         const { data: comments } = await octokit.rest.issues.listComments({

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -40,9 +40,25 @@ async function run() {
         const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/job/${jobId}?pr=${prNumber}#step:${stepNumber}:1`;
 
         // Create comment as markdown
-        const fullCommentBody = `### ${language.toUpperCase()} \n` +
+        const fullCommentBody = `## ${language.toUpperCase()} \n` +
             `You can check generated code in ${language}\n\n` +
-            `[Check the diff here](${ url })`;
+            `[Check the diff here](${url})`;
+
+        // check language is one of ruby or php, if so, add comment "You may need to modify code when webhook event is added. Parser is not genareted automatically. Please add test and modify code manually in each repository."
+        // check webhook event is added
+        if (language === 'ruby' || language === 'php') {
+            const { data: { files } } = await octokit.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+            });
+
+            const isWebhookEventAdded = files.some(file => file.filename.includes('webhook.yml'));
+            if (isWebhookEventAdded) {
+                fullCommentBody += `\n\nYou may need to modify code when webhook event is added. Parser is not genareted automatically. Please add test and modify code manually in each repository before release.`;
+            }
+        }
+
 
         // Delete the previous comment if it exists
         const { data: comments } = await octokit.rest.issues.listComments({

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -39,10 +39,10 @@ async function run() {
 
         const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/job/${jobId}?pr=${prNumber}#step:${stepNumber}:1`;
 
-        const fullCommentBody = `
-        ## [$language] Code generation completed
-        Generated code can be seen here(${language})\n\n[View logs here](${url})
-        `;
+        // Create comment as markdown
+        const fullCommentBody = `### ${language.toUpperCase()} \n` +
+            `You can check generated code in ${language}\n\n` +
+            `[Check the diff here](${ url })`;
 
         // Delete the previous comment if it exists
         const { data: comments } = await octokit.rest.issues.listComments({

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -30,10 +30,12 @@ async function run() {
             issue_number: prNumber,
         });
 
+        const medadataForComment = `<!-- ${jobName}-comment -->`;
+
         for (const comment of comments) {
             if (
                 comment.user.login === 'github-actions[bot]' &&
-                comment.body.includes(`<!-- ${jobName}-comment -->`)
+                comment.body.includes(medadataForComment)
             ) {
                 await octokit.rest.issues.deleteComment({
                     owner: context.repo.owner,
@@ -77,7 +79,7 @@ async function run() {
             const isWebhookEventAdded = files.some(file => file.filename.includes('webhook.yml'));
             if (isWebhookEventAdded) {
                 fullCommentBody += "\n\n⚠️You may need to modify code when a webhook event is added, even when tests are passed." +
-                `Parser in line - bot - sdk - ${ language } in not generated automatically.` +
+                `Parser in line-bot-sdk-${ language } in not generated automatically.` +
                 "Please add tests and modify parser manually in each repository before release.";
             }
         }
@@ -86,7 +88,7 @@ async function run() {
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: prNumber,
-            body: `<!-- ${jobName}-comment -->\n${fullCommentBody}`,
+            body: `${medadataForComment}\n${fullCommentBody}`,
         });
     } catch (error) {
         core.setFailed(`Error in this script: ${error.message}`);

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -24,6 +24,7 @@ async function run() {
             run_id: runId,
         });
 
+
         console.log(`jobs: ${JSON.stringify(jobs, null, 2)}`);
 
         const currentJob = jobs.find(job => job.name === jobName);

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -76,8 +76,8 @@ async function run() {
             const isWebhookEventAdded = files.some(file => file.filename.includes('webhook.yml'));
             if (isWebhookEventAdded) {
                 fullCommentBody += "\n\n⚠️You may need to modify code when a webhook event is added, even when tests are passed." +
-                `Parser in line-bot-sdk-${ language } in not generated automatically.` +
-                "Please add tests and modify parser manually in each repository before release.";
+                    `Parser in line-bot-sdk-${language} in not generated automatically.` +
+                    "Please add tests and modify parser manually in each repository before release.";
             }
         }
 

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -15,14 +15,6 @@ async function run() {
         const runId = context.runId;
         const jobName = context.job;
 
-        // Get the job ID and step number
-        const { data: { jobs } } = await octokit.rest.actions.listJobsForWorkflowRun({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            run_id: runId,
-        });
-
-
         // Delete the previous comment if it exists
         const { data: comments } = await octokit.rest.issues.listComments({
             owner: context.repo.owner,
@@ -46,6 +38,11 @@ async function run() {
         }
 
         // Post the new comment
+        const { data: { jobs } } = await octokit.rest.actions.listJobsForWorkflowRun({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: runId,
+        });
 
         const currentJob = jobs.find(job => job.name === jobName);
         if (!currentJob) {
@@ -91,6 +88,7 @@ async function run() {
             body: `${medadataForComment}\n${fullCommentBody}`,
         });
     } catch (error) {
+        console.error(error);
         core.setFailed(`Error in this script: ${error.message}`);
     }
 }

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -43,7 +43,10 @@ async function run() {
 
         const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/job/${jobId}?pr=${prNumber}#step:${stepNumber}:1`;
 
-        const fullCommentBody = `Generated code can be seen here(${language})\n\n[View logs here](${url})`;
+        const fullCommentBody = `
+        ## [$language] Code generation completed
+        Generated code can be seen here(${language})\n\n[View logs here](${url})
+        `;
 
         // 以前のコメントを削除
         const { data: comments } = await octokit.rest.issues.listComments({

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -47,7 +47,7 @@ async function run() {
         // check language is one of ruby or php, if so, add comment "You may need to modify code when webhook event is added. Parser is not genareted automatically. Please add test and modify code manually in each repository."
         // check webhook event is added
         if (language === 'ruby' || language === 'php') {
-            const { data: { files } } = await octokit.rest.pulls.listFiles({
+            const { data: files } = await octokit.rest.pulls.listFiles({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: prNumber,
@@ -55,9 +55,10 @@ async function run() {
 
             const isWebhookEventAdded = files.some(file => file.filename.includes('webhook.yml'));
             if (isWebhookEventAdded) {
-                fullCommentBody += `\n\nYou may need to modify code when webhook event is added. Parser is not genareted automatically. Please add test and modify code manually in each repository before release.`;
+                fullCommentBody += `\n\nYou may need to modify code when a webhook event is added. Parser is not generated automatically. Please add tests and modify code manually in each repository before release.`;
             }
         }
+
 
 
         // Delete the previous comment if it exists

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -1,0 +1,74 @@
+const github = require('@actions/github');
+const core = require('@actions/core');
+
+async function run() {
+    try {
+        const token = process.env.GITHUB_TOKEN;
+        const octokit = github.getOctokit(token);
+        const context = github.context;
+
+        const commentBody = core.getInput('language');
+        const stepName = 'Show diff'
+
+        const prNumber = context.payload.pull_request.number;
+        const runId = context.runId;
+        const jobName = context.job;
+
+        // ジョブIDとステップ番号を取得
+        const { data: { jobs } } = await octokit.rest.actions.listJobsForWorkflowRun({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: runId,
+        });
+
+        const currentJob = jobs.find(job => job.name === jobName);
+        if (!currentJob) {
+            throw new Error(`Job ${jobName} not found`);
+        }
+
+        const jobId = currentJob.id;
+
+        const step = currentJob.steps.find(step => step.name === stepName);
+        if (!step) {
+            throw new Error(`Step '${stepName}' not found`);
+        }
+
+        const stepNumber = currentJob.steps.indexOf(step) + 1;
+
+        const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/jobs/${jobId}?pr=${prNumber}#step:${stepNumber}:1`;
+
+        const fullCommentBody = `Generated code can be seen here(${commentBody})\n\n[View logs here](${url})`;
+
+        // 以前のコメントを削除
+        const { data: comments } = await octokit.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+        });
+
+        for (const comment of comments) {
+            if (
+                comment.user.login === 'github-actions[bot]' &&
+                comment.body.includes(`<!-- ${jobName}-comment -->`)
+            ) {
+                await octokit.rest.issues.deleteComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: comment.id,
+                });
+            }
+        }
+
+        // 新しいコメントを投稿
+        await octokit.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+            body: `<!-- ${jobName}-comment -->\n${fullCommentBody}`,
+        });
+    } catch (error) {
+        core.setFailed(error.message);
+    }
+}
+
+run();

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -41,7 +41,7 @@ async function run() {
 
         const stepNumber = currentJob.steps.indexOf(step) + 1;
 
-        const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/jobs/${jobId}?pr=${prNumber}#step:${stepNumber}:1`;
+        const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/job/${jobId}?pr=${prNumber}#step:${stepNumber}:1`;
 
         const fullCommentBody = `Generated code can be seen here(${language})\n\n[View logs here](${url})`;
 

--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -76,7 +76,9 @@ async function run() {
 
             const isWebhookEventAdded = files.some(file => file.filename.includes('webhook.yml'));
             if (isWebhookEventAdded) {
-                fullCommentBody += `\n\nYou may need to modify code when a webhook event is added. Parser is not generated automatically. Please add tests and modify code manually in each repository before release.`;
+                fullCommentBody += "\n\n⚠️You may need to modify code when a webhook event is added, even when tests are passed." +
+                `Parser in line - bot - sdk - ${ language } in not generated automatically.` +
+                "Please add tests and modify parser manually in each repository before release.";
             }
         }
 

--- a/.github/actions/post-comment-action/package-lock.json
+++ b/.github/actions/post-comment-action/package-lock.json
@@ -1,0 +1,268 @@
+{
+    "name": "post-comment-action",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "post-comment-action",
+            "version": "1.0.0",
+            "dependencies": {
+                "@actions/core": "^1.2.4",
+                "@actions/github": "^4.0.0"
+            }
+        },
+        "node_modules/@actions/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+            "dependencies": {
+                "@actions/exec": "^1.1.1",
+                "@actions/http-client": "^2.0.1"
+            }
+        },
+        "node_modules/@actions/exec": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+            "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+            "dependencies": {
+                "@actions/io": "^1.0.1"
+            }
+        },
+        "node_modules/@actions/github": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-4.0.0.tgz",
+            "integrity": "sha512-Ej/Y2E+VV6sR9X7pWL5F3VgEWrABaT292DRqRU6R4hnQjPtC/zD3nagxVdXWiRQvYDh8kHXo7IDmG42eJ/dOMA==",
+            "dependencies": {
+                "@actions/http-client": "^1.0.8",
+                "@octokit/core": "^3.0.0",
+                "@octokit/plugin-paginate-rest": "^2.2.3",
+                "@octokit/plugin-rest-endpoint-methods": "^4.0.0"
+            }
+        },
+        "node_modules/@actions/github/node_modules/@actions/http-client": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+            "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+            "dependencies": {
+                "tunnel": "0.0.6"
+            }
+        },
+        "node_modules/@actions/http-client": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+            "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+            "dependencies": {
+                "tunnel": "^0.0.6",
+                "undici": "^5.25.4"
+            }
+        },
+        "node_modules/@actions/io": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+            "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
+        },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@octokit/auth-token": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+            "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+            "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+            "dependencies": {
+                "@octokit/auth-token": "^2.4.4",
+                "@octokit/graphql": "^4.5.8",
+                "@octokit/request": "^5.6.3",
+                "@octokit/request-error": "^2.0.5",
+                "@octokit/types": "^6.0.3",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "6.0.12",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+            "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+            "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+            "dependencies": {
+                "@octokit/request": "^5.6.0",
+                "@octokit/types": "^6.0.3",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "12.11.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+            "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "2.21.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+            "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+            "dependencies": {
+                "@octokit/types": "^6.40.0"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=2"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "4.15.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.15.1.tgz",
+            "integrity": "sha512-4gQg4ySoW7ktKB0Mf38fHzcSffVZd6mT5deJQtpqkuPuAqzlED5AJTeW8Uk7dPRn7KaOlWcXB0MedTFJU1j4qA==",
+            "dependencies": {
+                "@octokit/types": "^6.13.0",
+                "deprecation": "^2.3.1"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+            "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+            "dependencies": {
+                "@octokit/endpoint": "^6.0.1",
+                "@octokit/request-error": "^2.1.0",
+                "@octokit/types": "^6.16.1",
+                "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+            "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "6.41.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+            "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+            "dependencies": {
+                "@octokit/openapi-types": "^12.11.0"
+            }
+        },
+        "node_modules/before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+        },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+        },
+        "node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "node_modules/tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+            }
+        },
+        "node_modules/undici": {
+            "version": "5.28.4",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+            "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
+        },
+        "node_modules/universal-user-agent": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+        }
+    }
+}

--- a/.github/actions/post-comment-action/package.json
+++ b/.github/actions/post-comment-action/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "post-comment-action",
+    "version": "1.0.0",
+    "description": "Post a comment on a pull request",
+    "main": "main.js",
+    "dependencies": {
+        "@actions/core": "^1.2.4",
+        "@actions/github": "^4.0.0"
+    }
+}

--- a/.github/actions/post-comment-action/package.json
+++ b/.github/actions/post-comment-action/package.json
@@ -1,7 +1,7 @@
 {
     "name": "post-comment-action",
     "version": "1.0.0",
-    "description": "Post a comment on a pull request",
+    "description": "Post comments on a pull request",
     "main": "main.js",
     "dependencies": {
         "@actions/core": "^1.2.4",

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -200,13 +200,6 @@ jobs:
         env:
           PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
           PR_REF: ${{ github.event.pull_request.head.ref }}
-      - name: a
-        run: |
-          ls -a
-          ls line-openapi -a
-          ls line-openapi/.github/actions
-          ls line-openapi/.github/actions/post-comment-action
-
 
       # https://github.com/line/line-bot-sdk-nodejs/blob/master/.github/workflows/test.yml
       - name: actions/setup-java@v3

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -42,9 +42,10 @@ jobs:
           git diff --color=always --staged
 
       - name: Post PR comment
-        uses: ./.github/actions/post-comment-action
+        uses: ./line-openapi/.github/actions/post-comment-action
         with:
           language: java
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Execute Java SDK test
         run: ./gradlew build
@@ -90,9 +91,10 @@ jobs:
           git diff --color=always --staged
 
       - name: Post PR comment
-        uses: ./.github/actions/post-comment-action
+        uses: ./line-openapi/.github/actions/post-comment-action
         with:
           language: python
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update version in linebot/__about__.py
         run: |
@@ -171,9 +173,10 @@ jobs:
           git diff --color=always --staged
 
       - name: Post PR comment
-        uses: ./.github/actions/post-comment-action
+        uses: ./line-openapi/.github/actions/post-comment-action
         with:
           language: php
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run unit tests
         run: ./vendor/bin/phpunit --test-suffix=Test.php
@@ -233,6 +236,7 @@ jobs:
         uses: ./line-openapi/.github/actions/post-comment-action
         with:
           language: nodejs
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test Project
         run: export NODE_OPTIONS=--max-old-space-size=6144; npm test
@@ -287,9 +291,10 @@ jobs:
           git diff --color=always --staged
 
       - name: Post PR comment
-        uses: ./.github/actions/post-comment-action
+        uses: ./line-openapi/.github/actions/post-comment-action
         with:
           language: go
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run tests
         run: go test ./...

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -197,7 +197,8 @@ jobs:
         env:
           PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
           PR_REF: ${{ github.event.pull_request.head.ref }}
-      - run: |
+      - name: a
+        run: |
           ls -a
           ls line-openapi -a
           ls line-openapi/.github/actions

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -197,6 +197,12 @@ jobs:
         env:
           PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
           PR_REF: ${{ github.event.pull_request.head.ref }}
+      - run: |
+          ls -a
+          ls line-openapi -a
+          ls line-openapi/.github/actions
+          ls line-openapi/.github/actions/post-comment-action
+
 
       # https://github.com/line/line-bot-sdk-nodejs/blob/master/.github/workflows/test.yml
       - name: actions/setup-java@v3

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -41,6 +41,11 @@ jobs:
           git add .
           git diff --color=always --staged
 
+      - name: Post PR comment
+        uses: ./.github/actions/post-comment-action
+        with:
+          language: java
+
       - name: Execute Java SDK test
         run: ./gradlew build
 
@@ -83,6 +88,11 @@ jobs:
         run: |
           git add .
           git diff --color=always --staged
+
+      - name: Post PR comment
+        uses: ./.github/actions/post-comment-action
+        with:
+          language: python
 
       - name: Update version in linebot/__about__.py
         run: |
@@ -160,6 +170,11 @@ jobs:
           git add .
           git diff --color=always --staged
 
+      - name: Post PR comment
+        uses: ./.github/actions/post-comment-action
+        with:
+          language: php
+
       - name: Run unit tests
         run: ./vendor/bin/phpunit --test-suffix=Test.php
 
@@ -207,6 +222,11 @@ jobs:
           git add .
           git diff --color=always --staged
 
+      - name: Post PR comment
+        uses: ./.github/actions/post-comment-action
+        with:
+          language: nodejs
+
       - name: Test Project
         run: export NODE_OPTIONS=--max-old-space-size=6144; npm test
 
@@ -247,10 +267,10 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.21
-  
+
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest
-  
+
       - name: Generate code
         run: python generate-code.py
 
@@ -259,12 +279,17 @@ jobs:
           git add .
           git diff --color=always --staged
 
+      - name: Post PR comment
+        uses: ./.github/actions/post-comment-action
+        with:
+          language: go
+
       - name: run tests
         run: go test ./...
-  
+
       - name: go vet
         run: go vet $(go list ./... | grep -v /examples/)
-  
+
       - name: Compile example scripts
         run: |
           for file in $(find ./examples/ -name '*.go'); do

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -223,7 +223,7 @@ jobs:
           git diff --color=always --staged
 
       - name: Post PR comment
-        uses: ./.github/actions/post-comment-action
+        uses: ./line-openapi/.github/actions/post-comment-action
         with:
           language: nodejs
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /tmp/
 /node_modules/
 .idea
+
+
+node_modules

--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -3789,9 +3789,6 @@ components:
         width:
           type: integer
           format: int32
-        a:
-          type: integer
-          format: int32
     ImagemapAction:
       externalDocs:
         url: https://developers.line.biz/en/reference/messaging-api/#imagemap-action-objects

--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -3789,6 +3789,9 @@ components:
         width:
           type: integer
           format: int32
+        a:
+          type: integer
+          format: int32
     ImagemapAction:
       externalDocs:
         url: https://developers.line.biz/en/reference/messaging-api/#imagemap-action-objects

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "line-bot-openapi",
+  "name": "line-openapi",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/webhook.yml
+++ b/webhook.yml
@@ -27,6 +27,7 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/CallbackRequest"
+
       responses:
         "200":
           description: "OK"


### PR DESCRIPTION
In the `Show diff` step, all jobs display the differences of the generated code. While some members have navigated by opening the GitHub Actions job URL, it should be more convenient to comment directly on the PR.

This change supports that.

(Additional Notes on the Comments)
1. Since the generated code may be updated with each additional commit, the job deletes old comments containing old job URLs if present.
2. Some generators are incomplete, so the comment shows tasks directed to the person who updated the OpenAPI YAML, especially when `webhook.yml` is updated.